### PR TITLE
Add example pages

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,34 @@
+import Header from "@/components/Header";
+import Sidebar from "@/components/Sidebar";
+import Footer from "@/components/Footer";
+import PageContainer from "@/components/PageContainer";
+
+const metrics = [
+  { id: 1, label: "Ventas", value: 1200 },
+  { id: 2, label: "Clientes", value: 300 },
+  { id: 3, label: "Ingresos", value: 45000 },
+  { id: 4, label: "Reembolsos", value: 12 },
+];
+
+export default function DashboardPage() {
+  return (
+    <div className="min-h-screen grid md:grid-cols-[200px_1fr]">
+      <Sidebar />
+      <div className="flex flex-col">
+        <Header />
+        <PageContainer>
+          <h1 className="text-xl font-semibold mb-4">Dashboard</h1>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {metrics.map((m) => (
+              <div key={m.id} className="p-4 border rounded text-center">
+                <p className="text-sm text-gray-500">{m.label}</p>
+                <p className="text-2xl font-bold">{m.value}</p>
+              </div>
+            ))}
+          </div>
+        </PageContainer>
+        <Footer />
+      </div>
+    </div>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,21 @@
+import { InputText, InputPassword, Input2FA, ButtonPrimary } from "@/src/components/ui";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import PageContainer from "@/components/PageContainer";
+
+export default function LoginPage() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <PageContainer>
+        <form className="mx-auto max-w-sm flex flex-col gap-4">
+          <InputText type="email" placeholder="Email" required />
+          <InputPassword placeholder="Contraseña" required />
+          <Input2FA placeholder="Código 2FA (opcional)" />
+          <ButtonPrimary type="submit">Ingresar</ButtonPrimary>
+        </form>
+      </PageContainer>
+      <Footer />
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,103 +1,48 @@
-import Image from "next/image";
+import Header from "@/components/Header";
+import Sidebar from "@/components/Sidebar";
+import Footer from "@/components/Footer";
+import PageContainer from "@/components/PageContainer";
+import ProductCard from "@/components/ProductCard";
+
+const products = [
+  {
+    id: 1,
+    imageSrc: "/next.svg",
+    title: "Producto 1",
+    price: 100,
+    installmentText: "12 cuotas de $10",
+  },
+  {
+    id: 2,
+    imageSrc: "/vercel.svg",
+    title: "Producto 2",
+    price: 200,
+    installmentText: "12 cuotas de $20",
+  },
+  {
+    id: 3,
+    imageSrc: "/globe.svg",
+    title: "Producto 3",
+    price: 300,
+    installmentText: "12 cuotas de $30",
+  },
+];
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+    <div className="min-h-screen grid md:grid-cols-[200px_1fr]">
+      <Sidebar />
+      <div className="flex flex-col">
+        <Header />
+        <PageContainer>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {products.map((p) => (
+              <ProductCard key={p.id} {...p} />
+            ))}
+          </div>
+        </PageContainer>
+        <Footer />
+      </div>
     </div>
   );
 }

--- a/app/request/page.tsx
+++ b/app/request/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { useState } from 'react';
+import { InputText, ButtonPrimary } from "@/src/components/ui";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import PageContainer from "@/components/PageContainer";
+
+export default function RequestPage() {
+  const [amount, setAmount] = useState('');
+  const [months, setMonths] = useState('');
+  const [payment, setPayment] = useState<number | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const a = parseFloat(amount);
+    const m = parseInt(months, 10);
+    if (!isNaN(a) && !isNaN(m) && m > 0) {
+      setPayment(a / m);
+    }
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <PageContainer>
+        <h1 className="text-xl font-semibold mb-4">Simulador de compra</h1>
+        <form onSubmit={handleSubmit} className="mx-auto max-w-sm flex flex-col gap-4">
+          <InputText
+            type="number"
+            placeholder="Monto"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+          />
+          <InputText
+            type="number"
+            placeholder="Meses"
+            value={months}
+            onChange={(e) => setMonths(e.target.value)}
+          />
+          <ButtonPrimary type="submit">Calcular</ButtonPrimary>
+        </form>
+        {payment !== null && (
+          <p className="mt-4 text-center">Cuota estimada: ${payment.toFixed(2)}</p>
+        )}
+      </PageContainer>
+      <Footer />
+    </div>
+  );
+}

--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -1,0 +1,16 @@
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import PageContainer from "@/components/PageContainer";
+
+export default function SuccessPage() {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <PageContainer>
+        <h1 className="text-xl font-semibold mb-4 text-center">¡Compra exitosa!</h1>
+        <p className="text-center">Pronto recibirás un correo con los detalles de tu compra.</p>
+      </PageContainer>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/ui/ButtonIcon.tsx
+++ b/src/components/ui/ButtonIcon.tsx
@@ -1,6 +1,6 @@
 import { ButtonHTMLAttributes } from "react";
 
-export interface ButtonIconProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
+export type ButtonIconProps = ButtonHTMLAttributes<HTMLButtonElement>;
 
 export default function ButtonIcon({ className = "", ...props }: ButtonIconProps) {
   return (

--- a/src/components/ui/ButtonPrimary.tsx
+++ b/src/components/ui/ButtonPrimary.tsx
@@ -1,6 +1,6 @@
 import { ButtonHTMLAttributes } from "react";
 
-export interface ButtonPrimaryProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
+export type ButtonPrimaryProps = ButtonHTMLAttributes<HTMLButtonElement>;
 
 export default function ButtonPrimary({ className = "", ...props }: ButtonPrimaryProps) {
   return (

--- a/src/components/ui/ButtonSecondary.tsx
+++ b/src/components/ui/ButtonSecondary.tsx
@@ -1,6 +1,6 @@
 import { ButtonHTMLAttributes } from "react";
 
-export interface ButtonSecondaryProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
+export type ButtonSecondaryProps = ButtonHTMLAttributes<HTMLButtonElement>;
 
 export default function ButtonSecondary({ className = "", ...props }: ButtonSecondaryProps) {
   return (

--- a/src/components/ui/Input2FA.tsx
+++ b/src/components/ui/Input2FA.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from "react";
 
-export interface Input2FAProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type Input2FAProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input2FA = forwardRef<HTMLInputElement, Input2FAProps>(
   ({ className = "", ...props }, ref) => (

--- a/src/components/ui/InputPassword.tsx
+++ b/src/components/ui/InputPassword.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from "react";
 
-export interface InputPasswordProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputPasswordProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const InputPassword = forwardRef<HTMLInputElement, InputPasswordProps>(
   ({ className = "", ...props }, ref) => (

--- a/src/components/ui/InputText.tsx
+++ b/src/components/ui/InputText.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from "react";
 
-export interface InputTextProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputTextProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const InputText = forwardRef<HTMLInputElement, InputTextProps>(
   ({ className = "", ...props }, ref) => (


### PR DESCRIPTION
## Summary
- switch UI component interfaces to type aliases
- build out example pages: home marketplace, login, dashboard, request and success

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font file from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_6875bda6fbc0832a9514d633353017a3