### PR TITLE
Add supabase client and utilities

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,0 +1,15 @@
+export async function getQuoteRecommendation(): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY
+
+  const response = await fetch('https://api.openai.com/v1/quotes', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({ prompt: 'quote recommendation' })
+  })
+
+  const data = await response.json()
+  return data.recommendation as string
+}

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -1,0 +1,5 @@
+export async function getEquifaxScore(ci: string): Promise<number> {
+  void ci
+  // Mock implementation of an Equifax score lookup
+  return 300 + Math.floor(Math.random() * 400)
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Summary
- initialize Supabase client from environment variables
- mock Equifax score lookup
- simulate quote recommendation via OpenAI fetch

## Testing
- `npm run lint`
- `npm run build` *(fails: failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6875bf2850f4832a93ca5475f9b76cc8