### PR TITLE
Add fintech UI components

### DIFF
--- a/src/components/ui/Alert.tsx
+++ b/src/components/ui/Alert.tsx
@@ -1,0 +1,27 @@
+'use client';
+import { ReactNode } from 'react';
+
+export interface AlertProps {
+  variant?: 'success' | 'error' | 'info';
+  children: ReactNode;
+}
+
+const variantStyles = {
+  success: 'bg-[#10B981]/10 text-[#10B981] border-[#10B981]',
+  error: 'bg-red-100 text-red-600 border-red-600',
+  info: 'bg-blue-100 text-[#1D4ED8] border-[#1D4ED8]',
+};
+
+export default function Alert({ variant = 'info', children }: AlertProps) {
+  const classes = variantStyles[variant];
+  return (
+    <div className={`border-l-4 p-3 rounded-md ${classes} font-[\'Inter\',sans-serif]`}>
+      {children}
+    </div>
+  );
+}
+
+/** Example Usage:
+ *
+ * <Alert variant="success">Operación exitosa</Alert>
+ */

--- a/src/components/ui/ChatWidget.tsx
+++ b/src/components/ui/ChatWidget.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { useState } from 'react';
+import InputText from './InputText';
+import ButtonPrimary from './ButtonPrimary';
+
+export default function ChatWidget() {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState('');
+  const [messages, setMessages] = useState<string[]>([]);
+
+  const handleSend = () => {
+    if (!text.trim()) return;
+    setMessages((m) => [...m, text.trim()]);
+    setText('');
+  };
+
+  return (
+    <div className="fixed bottom-4 right-4 z-40 font-[\'Inter\',sans-serif]">
+      {open && (
+        <div className="bg-white shadow-lg border rounded-lg w-72 flex flex-col h-80 mb-2">
+          <div className="flex-1 overflow-y-auto p-2 space-y-1 text-sm">
+            {messages.map((msg, i) => (
+              <div key={i} className="p-2 bg-gray-100 rounded-md">
+                {msg}
+              </div>
+            ))}
+          </div>
+          <div className="p-2 flex gap-2 border-t">
+            <InputText
+              className="flex-1"
+              placeholder="Escribe tu mensaje"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+            />
+            <ButtonPrimary type="button" onClick={handleSend} className="shrink-0 px-3">
+              Enviar
+            </ButtonPrimary>
+          </div>
+        </div>
+      )}
+      <ButtonPrimary type="button" onClick={() => setOpen(!open)} className="rounded-full px-3 py-2">
+        {open ? 'Cerrar' : 'Chat'}
+      </ButtonPrimary>
+    </div>
+  );
+}
+
+/** Example Usage:
+ *
+ * <ChatWidget />
+ */

--- a/src/components/ui/LoadingSpinner.tsx
+++ b/src/components/ui/LoadingSpinner.tsx
@@ -1,0 +1,20 @@
+'use client';
+export interface LoadingSpinnerProps {
+  size?: number; // px
+}
+
+export default function LoadingSpinner({ size = 24 }: LoadingSpinnerProps) {
+  return (
+    <div className="flex items-center justify-center" style={{ height: size, width: size }}>
+      <div
+        className="border-4 border-[#1D4ED8] border-t-transparent rounded-full animate-spin"
+        style={{ width: size, height: size }}
+      />
+    </div>
+  );
+}
+
+/** Example Usage:
+ *
+ * <LoadingSpinner size={32} />
+ */

--- a/src/components/ui/LoginForm.tsx
+++ b/src/components/ui/LoginForm.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { useState } from 'react';
+import InputText from './InputText';
+import InputPassword from './InputPassword';
+import Input2FA from './Input2FA';
+import ButtonPrimary from './ButtonPrimary';
+
+export interface LoginFormProps {
+  onSubmit?: (values: { email: string; password: string; code?: string }) => void;
+}
+
+export default function LoginForm({ onSubmit }: LoginFormProps) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [code, setCode] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit?.({ email, password, code: code || undefined });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4 max-w-sm mx-auto font-[\'Inter\',sans-serif]">
+      <p className="text-center text-sm text-gray-600">Acceso restringido a empleados</p>
+      <InputText
+        type="email"
+        placeholder="Email corporativo"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <InputPassword
+        placeholder="Contraseña"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      <Input2FA
+        placeholder="Código 2FA (opcional)"
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+      />
+      <ButtonPrimary type="submit">Ingresar</ButtonPrimary>
+    </form>
+  );
+}
+
+/** Example Usage:
+ *
+ * <LoginForm onSubmit={(values) => console.log(values)} />
+ */

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,38 @@
+'use client';
+import { ReactNode } from 'react';
+import ButtonIcon from './ButtonIcon';
+
+export interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export default function Modal({ isOpen, onClose, children }: ModalProps) {
+  if (!isOpen) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="bg-white rounded-lg w-full max-w-md p-4 relative font-[\'Inter\',sans-serif]">
+        <ButtonIcon
+          aria-label="Cerrar"
+          onClick={onClose}
+          className="absolute right-2 top-2 text-gray-500 hover:text-gray-700"
+        >
+          ×
+        </ButtonIcon>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/** Example Usage:
+ *
+ * const [open, setOpen] = useState(false);
+ * <>
+ *   <ButtonPrimary onClick={() => setOpen(true)}>Abrir</ButtonPrimary>
+ *   <Modal isOpen={open} onClose={() => setOpen(false)}>
+ *     <p>Contenido del modal</p>
+ *   </Modal>
+ * </>
+ */

--- a/src/components/ui/ProgressBar.tsx
+++ b/src/components/ui/ProgressBar.tsx
@@ -1,0 +1,21 @@
+'use client';
+export interface ProgressBarProps {
+  value: number; // 0 to 100
+}
+
+export default function ProgressBar({ value }: ProgressBarProps) {
+  const width = Math.min(100, Math.max(0, value));
+  return (
+    <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+      <div
+        className="h-full bg-[#1D4ED8] transition-all"
+        style={{ width: `${width}%` }}
+      />
+    </div>
+  );
+}
+
+/** Example Usage:
+ *
+ * <ProgressBar value={50} />
+ */

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -4,4 +4,9 @@ export { default as Input2FA } from './Input2FA';
 export { default as ButtonPrimary } from './ButtonPrimary';
 export { default as ButtonSecondary } from './ButtonSecondary';
 export { default as ButtonIcon } from './ButtonIcon';
-
+export { default as LoginForm } from './LoginForm';
+export { default as Modal } from './Modal';
+export { default as ProgressBar } from './ProgressBar';
+export { default as LoadingSpinner } from './LoadingSpinner';
+export { default as Alert } from './Alert';
+export { default as ChatWidget } from './ChatWidget';


### PR DESCRIPTION
## Summary
- add login form component with optional 2FA
- create reusable modal
- implement progress bar and loading spinner
- provide alert component with variants
- add floating chat widget
- export new UI components

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6875c02119b8832a9117f0cd496f7cec