### PR TITLE
Add Supabase auth with 2FA and route protection

### DIFF
--- a/app/auth/AuthProvider.tsx
+++ b/app/auth/AuthProvider.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState } from 'react'
+import { Session, User } from '@supabase/supabase-js'
+import { supabase } from '@/lib/supabase/client'
+
+interface AuthContextType {
+  user: User | null
+  session: Session | null
+  loading: boolean
+  login: (email: string, password: string, code?: string) => Promise<void>
+  logout: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('AuthProvider missing')
+  return ctx
+}
+
+export default function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session)
+      setLoading(false)
+    })
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session)
+    })
+    return () => {
+      listener.subscription.unsubscribe()
+    }
+  }, [])
+
+  const loginFn = async (email: string, password: string, code?: string) => {
+    setLoading(true)
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    if (error) {
+      setLoading(false)
+      throw error
+    }
+    if (code) {
+      const { error: otpError } = await supabase.auth.verifyOtp({ token: code, type: 'totp' })
+      if (otpError) {
+        setLoading(false)
+        throw otpError
+      }
+    }
+    const { data } = await supabase.auth.getSession()
+    setSession(data.session)
+    setLoading(false)
+  }
+
+  const logoutFn = async () => {
+    setLoading(true)
+    await supabase.auth.signOut()
+    setSession(null)
+    setLoading(false)
+  }
+
+  const value: AuthContextType = {
+    user: session?.user ?? null,
+    session,
+    loading,
+    login: loginFn,
+    logout: logoutFn,
+  }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { ChatWidget } from "@/src/components/ui";
+import AuthProvider from "./auth/AuthProvider";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -21,7 +22,9 @@ export default function RootLayout({
   return (
     <html lang="es">
       <body className={`${inter.className} antialiased`}>
-        {children}
+        <AuthProvider>
+          {children}
+        </AuthProvider>
         {/* Chat de Soporte IA - visible en todas las páginas */}
         <ChatWidget />
       </body>

--- a/app/perfil/page.tsx
+++ b/app/perfil/page.tsx
@@ -1,0 +1,19 @@
+'use client'
+import { useAuth } from '../auth/AuthProvider'
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import PageContainer from '@/components/PageContainer'
+
+export default function PerfilPage() {
+  const { user } = useAuth()
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <PageContainer>
+        <h1 className="text-xl font-semibold mb-4">Perfil</h1>
+        <p className="mb-2">Email: {user?.email}</p>
+      </PageContainer>
+      <Footer />
+    </div>
+  )
+}

--- a/app/solicitudes/page.tsx
+++ b/app/solicitudes/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { useState } from 'react';
+import { InputText, ButtonPrimary } from "@/src/components/ui";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import PageContainer from "@/components/PageContainer";
+
+export default function SolicitudesPage() {
+  const [amount, setAmount] = useState('');
+  const [months, setMonths] = useState('');
+  const [payment, setPayment] = useState<number | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const a = parseFloat(amount);
+    const m = parseInt(months, 10);
+    if (!isNaN(a) && !isNaN(m) && m > 0) {
+      setPayment(a / m);
+    }
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <PageContainer>
+        <h1 className="text-xl font-semibold mb-4">Solicitudes de Crédito</h1>
+        <form onSubmit={handleSubmit} className="mx-auto max-w-sm flex flex-col gap-4">
+          <InputText
+            type="number"
+            placeholder="Monto"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+          />
+          <InputText
+            type="number"
+            placeholder="Meses"
+            value={months}
+            onChange={(e) => setMonths(e.target.value)}
+          />
+          <ButtonPrimary type="submit">Calcular</ButtonPrimary>
+        </form>
+        {payment !== null && (
+          <p className="mt-4 text-center">Cuota estimada: ${payment.toFixed(2)}</p>
+        )}
+      </PageContainer>
+      <Footer />
+    </div>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,10 +1,19 @@
+"use client";
 import Image from "next/image";
+import { useAuth } from "@/app/auth/AuthProvider";
 
 export default function Header() {
+  const { user, logout } = useAuth();
   return (
     <header className="flex items-center gap-3 p-4 border-b">
       <Image src="/next.svg" alt="Crediya logo" width={40} height={40} />
       <span className="font-semibold text-xl">Crediya</span>
+      {user && (
+        <div className="ml-auto flex items-center gap-2">
+          <span className="text-sm text-gray-600">{user.email}</span>
+          <button onClick={logout} className="text-sm text-blue-600 hover:underline">Salir</button>
+        </div>
+      )}
     </header>
   );
 }

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -5,8 +5,9 @@ export default function Sidebar() {
     <aside className="w-60 p-4 border-r min-h-screen">
       <nav className="flex flex-col gap-2">
         <Link className="hover:underline" href="/dashboard">Dashboard</Link>
-        <Link className="hover:underline" href="/employees">Empleados</Link>
-        <Link className="hover:underline" href="/admin">Administración</Link>
+        <Link className="hover:underline" href="/catalogo">Catálogo</Link>
+        <Link className="hover:underline" href="/solicitudes">Solicitudes</Link>
+        <Link className="hover:underline" href="/perfil">Perfil</Link>
       </nav>
     </aside>
   );

--- a/lib/auth/auth-helpers.ts
+++ b/lib/auth/auth-helpers.ts
@@ -1,0 +1,18 @@
+import { supabase } from '@/lib/supabase/client'
+
+export async function login(email: string, password: string) {
+  return supabase.auth.signInWithPassword({ email, password })
+}
+
+export async function verify2FA(code: string) {
+  return supabase.auth.verifyOtp({ token: code, type: 'totp' })
+}
+
+export async function logout() {
+  return supabase.auth.signOut()
+}
+
+export async function getSession() {
+  const { data } = await supabase.auth.getSession()
+  return data.session
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,6 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
+import { createBrowserClient } from '@supabase/auth-helpers-nextjs'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+export const supabase = createBrowserClient(supabaseUrl, supabaseAnonKey)

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs'
+
+export async function middleware(req: NextRequest) {
+  const res = NextResponse.next()
+  const supabase = createMiddlewareClient({ req, res })
+  const { data: { session } } = await supabase.auth.getSession()
+
+  const protectedPaths = ['/dashboard', '/catalogo', '/perfil', '/solicitudes']
+  const path = req.nextUrl.pathname
+
+  const isProtected = protectedPaths.some((p) => path.startsWith(p))
+
+  if (!session && isProtected) {
+    const loginUrl = new URL('/login', req.url)
+    loginUrl.searchParams.set('redirect', path)
+    return NextResponse.redirect(loginUrl)
+  }
+
+  if (session && path === '/login') {
+    return NextResponse.redirect(new URL('/dashboard', req.url))
+  }
+
+  return res
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/catalogo/:path*', '/perfil/:path*', '/solicitudes/:path*', '/login']
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
+        "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/supabase-js": "^2.51.0",
         "next": "15.4.1",
         "react": "19.1.0",
@@ -990,6 +991,33 @@
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@supabase/auth-helpers-nextjs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.10.0.tgz",
+      "integrity": "sha512-2dfOGsM4yZt0oS4TPiE7bD4vf7EVz7NRz/IJrV6vLg0GP7sMUx8wndv2euLGq4BjN9lUCpu6DG/uCC8j+ylwPg==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-helpers-shared": "0.7.0",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.39.8"
+      }
+    },
+    "node_modules/@supabase/auth-helpers-shared": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.7.0.tgz",
+      "integrity": "sha512-FBFf2ei2R7QC+B/5wWkthMha8Ca2bWHAndN+syfuEUUfufv4mLcAgBCcgNg5nJR8L0gZfyuaxgubtOc9aW3Cpg==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.14.4"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.39.8"
+      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.71.0",
@@ -4218,6 +4246,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5404,6 +5441,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/supabase-js": "^2.51.0",
     "next": "15.4.1",
     "react": "19.1.0",


### PR DESCRIPTION
## Summary
- add `AuthProvider` context for Supabase authentication
- create Supabase client and helper functions
- protect private routes via `middleware.ts`
- integrate auth provider in layout
- update login page to use context
- add profile and solicitudes pages
- show logout button in header and update sidebar links
- install `@supabase/auth-helpers-nextjs`

## Testing
- `npm run build` *(fails: Failed to fetch font files)*

------
https://chatgpt.com/codex/tasks/task_e_6876af369bd0832a953f3fa39ed7c7b8