### PR TITLE
Add Supabase types and products API

### DIFF
--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { ProductSchema, PaginationSchema } from '@/lib/validations/schemas'
+import { z } from 'zod'
+import type { Database } from '@/lib/supabase/database.types'
+
+export async function GET(req: NextRequest) {
+  const supabase = createRouteHandlerClient<Database>({ cookies })
+  const { searchParams } = new URL(req.url)
+  const params = PaginationSchema.parse({
+    page: searchParams.get('page'),
+    limit: searchParams.get('limit'),
+    search: searchParams.get('search') ?? undefined
+  })
+  const from = (params.page - 1) * params.limit
+  let query = supabase
+    .from('products')
+    .select('*', { count: 'exact' })
+    .order('created_at', { ascending: false })
+    .range(from, from + params.limit - 1)
+
+  if (params.search) {
+    query = query.ilike('name', `%${params.search}%`)
+  }
+
+  const { data, error, count } = await query
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ data, count, page: params.page, limit: params.limit })
+}
+
+export async function POST(req: NextRequest) {
+  const supabase = createRouteHandlerClient<Database>({ cookies })
+  const json = await req.json()
+  const parse = ProductSchema.safeParse(json)
+  if (!parse.success) {
+    return NextResponse.json({ error: parse.error.flatten() }, { status: 400 })
+  }
+  const { data, error } = await supabase
+    .from('products')
+    .insert(parse.data)
+    .select()
+    .single()
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}
+
+export async function PUT(req: NextRequest) {
+  const supabase = createRouteHandlerClient<Database>({ cookies })
+  const json = await req.json()
+  const UpdateSchema = ProductSchema.extend({ id: z.string().uuid() })
+  const parse = UpdateSchema.safeParse(json)
+  if (!parse.success) {
+    return NextResponse.json({ error: parse.error.flatten() }, { status: 400 })
+  }
+  const { data, error } = await supabase
+    .from('products')
+    .update(parse.data)
+    .eq('id', parse.data.id)
+    .select()
+    .single()
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json(data)
+}
+
+export async function DELETE(req: NextRequest) {
+  const supabase = createRouteHandlerClient<Database>({ cookies })
+  const { searchParams } = new URL(req.url)
+  const id = searchParams.get('id')
+  if (!id) {
+    return NextResponse.json({ error: 'Missing id' }, { status: 400 })
+  }
+  const { error } = await supabase.from('products').delete().eq('id', id)
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ success: true })
+}

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -1,0 +1,167 @@
+export type Json = string | number | boolean | null | { [key: string]: Json } | Json[]
+
+export interface Database {
+  public: {
+    Tables: {
+      users: {
+        Row: {
+          id: string
+          email: string
+          name: string | null
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          email: string
+          name?: string | null
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          email?: string
+          name?: string | null
+          created_at?: string | null
+        }
+        Relationships: []
+      }
+      categories: {
+        Row: {
+          id: string
+          name: string
+          description: string | null
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          name: string
+          description?: string | null
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          name?: string
+          description?: string | null
+          created_at?: string | null
+        }
+        Relationships: []
+      }
+      products: {
+        Row: {
+          id: string
+          name: string
+          description: string | null
+          price: number
+          category_id: string | null
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          name: string
+          description?: string | null
+          price: number
+          category_id?: string | null
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          name?: string
+          description?: string | null
+          price?: number
+          category_id?: string | null
+          created_at?: string | null
+        }
+        Relationships: [{
+          foreignKeyName: "products_category_id_fkey"
+          columns: ["category_id"]
+          referencedRelation: "categories"
+          referencedColumns: ["id"]
+        }]
+      }
+      credit_requests: {
+        Row: {
+          id: string
+          user_id: string
+          product_id: string | null
+          amount: number
+          status: string
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          product_id?: string | null
+          amount: number
+          status?: string
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          product_id?: string | null
+          amount?: number
+          status?: string
+          created_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "credit_requests_user_id_fkey"
+            columns: ["user_id"]
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "credit_requests_product_id_fkey"
+            columns: ["product_id"]
+            referencedRelation: "products"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      transactions: {
+        Row: {
+          id: string
+          user_id: string
+          credit_request_id: string | null
+          amount: number
+          type: string
+          status: string
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          credit_request_id?: string | null
+          amount: number
+          type: string
+          status?: string
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          credit_request_id?: string | null
+          amount?: number
+          type?: string
+          status?: string
+          created_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "transactions_user_id_fkey"
+            columns: ["user_id"]
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_credit_request_id_fkey"
+            columns: ["credit_request_id"]
+            referencedRelation: "credit_requests"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+    }
+  }
+}
+
+export type Tables<T extends keyof Database["public"]["Tables"]> = Database["public"]["Tables"][T]["Row"]

--- a/lib/validations/schemas.ts
+++ b/lib/validations/schemas.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod'
+
+export const UserSchema = z.object({
+  id: z.string().uuid().optional(),
+  email: z.string().email(),
+  name: z.string().min(1).optional(),
+  created_at: z.string().optional()
+})
+
+export const CategorySchema = z.object({
+  id: z.string().uuid().optional(),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  created_at: z.string().optional()
+})
+
+export const ProductSchema = z.object({
+  id: z.string().uuid().optional(),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  price: z.number().nonnegative(),
+  category_id: z.string().uuid().nullable(),
+  created_at: z.string().optional()
+})
+
+export const CreditRequestSchema = z.object({
+  id: z.string().uuid().optional(),
+  user_id: z.string().uuid(),
+  product_id: z.string().uuid().nullable(),
+  amount: z.number().nonnegative(),
+  status: z.string().optional(),
+  created_at: z.string().optional()
+})
+
+export const TransactionSchema = z.object({
+  id: z.string().uuid().optional(),
+  user_id: z.string().uuid(),
+  credit_request_id: z.string().uuid().nullable(),
+  amount: z.number().nonnegative(),
+  type: z.string(),
+  status: z.string().optional(),
+  created_at: z.string().optional()
+})
+
+export const PaginationSchema = z.object({
+  page: z.coerce.number().min(1).default(1),
+  limit: z.coerce.number().min(1).max(100).default(10),
+  search: z.string().optional()
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@supabase/supabase-js": "^2.51.0",
         "next": "15.4.1",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -6343,6 +6344,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@supabase/supabase-js": "^2.51.0",
     "next": "15.4.1",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- define Supabase table types for `users`, `products`, `credit_requests`, `transactions` and `categories`
- add Zod validation schemas including pagination helpers
- implement `/api/products` route handler with CRUD features
- install `zod` dependency

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font file from `fonts.gstatic.com`)*

------
https://chatgpt.com/codex/tasks/task_e_6876b3e3bd60832ab6fae68d7ae9a9f5